### PR TITLE
Modify it so that the build succeeds in Xcode 26.

### DIFF
--- a/CircuitPro.xcodeproj/project.pbxproj
+++ b/CircuitPro.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5E2704182DF5F410008B26BC /* AboutWindow in Frameworks */ = {isa = PBXBuildFile; productRef = 5E2704172DF5F410008B26BC /* AboutWindow */; };
-		5ED3BD3E2DE7CA3E00F6DB0B /* WelcomeWindow in Frameworks */ = {isa = PBXBuildFile; productRef = 5ED3BD3D2DE7CA3E00F6DB0B /* WelcomeWindow */; };
+		7C2E4BB22E240EE000C933CF /* WelcomeWindow in Frameworks */ = {isa = PBXBuildFile; productRef = 7C2E4BB12E240EE000C933CF /* WelcomeWindow */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,7 +42,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5E2704182DF5F410008B26BC /* AboutWindow in Frameworks */,
-				5ED3BD3E2DE7CA3E00F6DB0B /* WelcomeWindow in Frameworks */,
+				7C2E4BB22E240EE000C933CF /* WelcomeWindow in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,8 +85,8 @@
 			);
 			name = CircuitPro;
 			packageProductDependencies = (
-				5ED3BD3D2DE7CA3E00F6DB0B /* WelcomeWindow */,
 				5E2704172DF5F410008B26BC /* AboutWindow */,
+				7C2E4BB12E240EE000C933CF /* WelcomeWindow */,
 			);
 			productName = Electron;
 			productReference = 5E5AB35A2D9C60330069B623 /* CircuitPro.app */;
@@ -118,8 +118,8 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				5E0B73522DDF58BE0061123B /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */,
-				5ED3BD3C2DE7CA3E00F6DB0B /* XCRemoteSwiftPackageReference "CodeEditWelcomeWindow" */,
 				5E2704162DF5F410008B26BC /* XCRemoteSwiftPackageReference "AboutWindow" */,
+				7C2E4BB02E240EE000C933CF /* XCRemoteSwiftPackageReference "WelcomeWindow" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5E5AB35B2D9C60330069B623 /* Products */;
@@ -301,7 +301,9 @@
 				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.circuitpro.CircuitPro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_INFER_ISOLATED_CONFORMANCES = NO;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -333,7 +335,9 @@
 				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.circuitpro.CircuitPro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_INFER_ISOLATED_CONFORMANCES = NO;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -378,12 +382,12 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		5ED3BD3C2DE7CA3E00F6DB0B /* XCRemoteSwiftPackageReference "CodeEditWelcomeWindow" */ = {
+		7C2E4BB02E240EE000C933CF /* XCRemoteSwiftPackageReference "WelcomeWindow" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/CodeEditApp/CodeEditWelcomeWindow";
+			repositoryURL = "https://github.com/happyjem/WelcomeWindow.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -394,9 +398,9 @@
 			package = 5E2704162DF5F410008B26BC /* XCRemoteSwiftPackageReference "AboutWindow" */;
 			productName = AboutWindow;
 		};
-		5ED3BD3D2DE7CA3E00F6DB0B /* WelcomeWindow */ = {
+		7C2E4BB12E240EE000C933CF /* WelcomeWindow */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5ED3BD3C2DE7CA3E00F6DB0B /* XCRemoteSwiftPackageReference "CodeEditWelcomeWindow" */;
+			package = 7C2E4BB02E240EE000C933CF /* XCRemoteSwiftPackageReference "WelcomeWindow" */;
 			productName = WelcomeWindow;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/CircuitPro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CircuitPro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7cea466af50b7627e244e6a4581ad586750aa30db49b2c7832883c263f683863",
+  "originHash" : "9db52e6d3f78e15fa542da4936b29fad2feecab71c7c29cea1916cabff9dd7da",
   "pins" : [
     {
       "identity" : "aboutwindow",
@@ -11,21 +11,21 @@
       }
     },
     {
-      "identity" : "codeeditwelcomewindow",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CodeEditApp/CodeEditWelcomeWindow",
-      "state" : {
-        "revision" : "a23cb09e34e781079981260aaa576e7e18969737",
-        "version" : "1.0.1"
-      }
-    },
-    {
       "identity" : "swiftlintplugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
         "revision" : "3780efccceaa87f17ec39638a9d263d0e742b71c",
         "version" : "0.59.1"
+      }
+    },
+    {
+      "identity" : "welcomewindow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/happyjem/WelcomeWindow.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "7f616fbf8c668f88751abfc086f77a58143c958c"
       }
     }
   ],


### PR DESCRIPTION
I modified the WelcomeWindows package while keeping Swift 5, and there are no issues with building or running the program.
Next, I’m planning to try applying Swift 6, but there are quite a few migration issues.
It doesn't seem easy without a thorough code analysis.
